### PR TITLE
Uses a string not a list of chars for the count.

### DIFF
--- a/lib/scrivener.ex
+++ b/lib/scrivener.ex
@@ -150,7 +150,7 @@ defmodule Scrivener do
     |> exclude(:order_by)
     |> exclude(:preload)
     |> exclude(:select)
-    |> select([e], count('*'))
+    |> select([e], count("*"))
     |> repo.one
   end
 


### PR DESCRIPTION
This was causing an issue when using the Ecto MySQL adapter. Fixes #9.

I don't know the best way to get the tests set up with MySQL right now, but I tested this within the application I found the problem and it worked.