### PR TITLE
fixed total entries when group by clause is used

### DIFF
--- a/lib/scrivener.ex
+++ b/lib/scrivener.ex
@@ -153,7 +153,7 @@ defmodule Scrivener do
 
     {query_sql, parameters} =  Ecto.Adapters.SQL.to_sql(:all, repo, stripped_query)
 
-    %{num_rows: 1, rows: [[count]]} = Ecto.Adapters.SQL.query(repo, "SELECT count(*) FROM (#{query_sql}) AS temp", parameters)
+    {:ok, %{num_rows: 1, rows: [[count]]}} = Ecto.Adapters.SQL.query(repo, "SELECT count(*) FROM (#{query_sql}) AS temp", parameters)
     count
   end
 

--- a/lib/scrivener.ex
+++ b/lib/scrivener.ex
@@ -146,12 +146,15 @@ defmodule Scrivener do
   end
 
   defp total_entries(query, repo) do
-    query
+    stripped_query = query
     |> exclude(:order_by)
     |> exclude(:preload)
     |> exclude(:select)
-    |> select([e], count("*"))
-    |> repo.one
+
+    {query_sql, parameters} =  Ecto.Adapters.SQL.to_sql(:all, repo, stripped_query)
+
+    %{num_rows: 1, rows: [[count]]} = Ecto.Adapters.SQL.query(repo, "SELECT count(*) FROM (#{query_sql}) AS temp", parameters)
+    count
   end
 
   defp total_pages(total_entries, page_size) do

--- a/test/support/post.ex
+++ b/test/support/post.ex
@@ -15,4 +15,8 @@ defmodule Scrivener.Post do
   def published(query) do
     query |> where([p], p.published == true)
   end
+
+  def unpublished(query) do
+    query |> where([p], p.published == false)
+  end
 end


### PR DESCRIPTION
paginate couldn't be used when a group by clause was given and there were multiple rows per record. see tests.

i have big doubts whether this is a good way to fix this. if you can think of a better way, please let me know. even if you don't want to merge this anyway...