### PR TITLE
Max page size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.1.0-dev
 
+* Allow configuring `max_page_size`
+
 ## 1.0.0
 
 * Initial release

--- a/lib/scrivener.ex
+++ b/lib/scrivener.ex
@@ -54,7 +54,7 @@ defmodule Scrivener do
 
   When `use`d, an optional default for `page_size` can be provided. If `page_size` is not provided a default of 10 will be used.
 
-  A `max_page_size` can also optionally can be provided. This enforces a hard ceiling for the page size, even if you're allow users of your application to specify `page_size` via query parameters. If not provided, there will be no limit to page size.
+  A `max_page_size` can also optionally can be provided. This enforces a hard ceiling for the page size, even if you allow users of your application to specify `page_size` via query parameters. If not provided, there will be no limit to page size.
 
       defmodule MyApp.Repo do
         use Ecto.Repo, ...

--- a/lib/scrivener.ex
+++ b/lib/scrivener.ex
@@ -8,7 +8,7 @@ defmodule Scrivener do
 
       defmodule MyApp.Repo do
         use Ecto.Repo, otp_app: :my_app
-        use Scrivener, page_size: 10
+        use Scrivener, page_size: 10, max_page_size: 100
       end
 
       defmodule MyApp.Person do
@@ -50,7 +50,11 @@ defmodule Scrivener do
   alias Scrivener.Page
 
   @doc """
-  Scrivener is meant to be `use`d by an Ecto repository. When `use`d, an optional default for `page_size` can be provided. If `page_size` is not provided a default of 10 will be used.
+  Scrivener is meant to be `use`d by an Ecto repository.
+
+  When `use`d, an optional default for `page_size` can be provided. If `page_size` is not provided a default of 10 will be used.
+
+  A `max_page_size` can also optionally can be provided. This enforces a hard ceiling for the page size, even if you're allow users of your application to specify `page_size` via query parameters. If not provided, there will be no limit to page size.
 
       defmodule MyApp.Repo do
         use Ecto.Repo, ...
@@ -59,10 +63,10 @@ defmodule Scrivener do
 
       defmodule MyApp.Repo do
         use Ecto.Repo, ...
-        use Scrivener, page_size: 5
+        use Scrivener, page_size: 5, max_page_size: 100
       end
 
-    When `use` is called a `paginate` function is defined in the Ecto repo. See the `paginate` documentation for more information.
+    When `use` is called, a `paginate` function is defined in the Ecto repo. See the `paginate` documentation for more information.
   """
   defmacro __using__(opts) do
     quote do

--- a/lib/scrivener/config.ex
+++ b/lib/scrivener/config.ex
@@ -24,19 +24,25 @@ defmodule Scrivener.Config do
 
   @doc false
   def new(repo, defaults, %{} = opts) do
-    default_page_size = default_page_size(defaults)
     page_number = opts["page"] |> to_int(1)
-    page_size = opts["page_size"] |> to_int(default_page_size)
 
     %Scrivener.Config{
       page_number: page_number,
-      page_size: page_size,
+      page_size: page_size(defaults, opts),
       repo: repo
     }
   end
 
-  defp default_page_size(page_size: page_size), do: page_size
-  defp default_page_size(_), do: 10
+  defp default_page_size(defaults) do
+    defaults[:page_size] || 10
+  end
+
+  def page_size(defaults, opts) do
+    default_page_size = default_page_size(defaults)
+    requested_page_size = opts["page_size"] |> to_int(default_page_size)
+
+    min(requested_page_size, defaults[:max_page_size])
+  end
 
   defp to_int(:error, default), do: default
   defp to_int(nil, default), do: default

--- a/test/scrivener_test.exs
+++ b/test/scrivener_test.exs
@@ -84,6 +84,14 @@ defmodule ScrivenerTest do
       assert page.total_pages == 2
     end
 
+    it "will respect the max_page_size configuration" do
+      page = Post
+      |> Post.published
+      |> Scrivener.Repo.paginate(%{"page" => "1", "page_size" => "20"})
+
+      assert page.page_size == 10
+    end
+
     it "can be provided a Scrivener.Config directly" do
       posts = create_posts
 

--- a/test/support/repo.ex
+++ b/test/support/repo.ex
@@ -1,4 +1,4 @@
 defmodule Scrivener.Repo do
   use Ecto.Repo, otp_app: :scrivener
-  use Scrivener, page_size: 5
+  use Scrivener, page_size: 5, max_page_size: 10
 end


### PR DESCRIPTION
This pull request adds a `max_page_size` configuration option. It allows you to set a hard ceiling on `page_size`, even if you're allowing users to specify it with a query parameter.

Fixes #16.