### PR TITLE
Ability to provide params with atoms

### DIFF
--- a/lib/scrivener/config.ex
+++ b/lib/scrivener/config.ex
@@ -24,7 +24,7 @@ defmodule Scrivener.Config do
 
   @doc false
   def new(repo, defaults, %{} = opts) do
-    page_number = opts["page"] |> to_int(1)
+    page_number = (opts["page"] || opts[:page]) |> to_int(1)
 
     %Scrivener.Config{
       page_number: page_number,
@@ -39,7 +39,7 @@ defmodule Scrivener.Config do
 
   def page_size(defaults, opts) do
     default_page_size = default_page_size(defaults)
-    requested_page_size = opts["page_size"] |> to_int(default_page_size)
+    requested_page_size = (opts["page_size"] || opts[:page_size]) |> to_int(default_page_size)
 
     min(requested_page_size, defaults[:max_page_size])
   end

--- a/test/scrivener_test.exs
+++ b/test/scrivener_test.exs
@@ -71,6 +71,19 @@ defmodule ScrivenerTest do
       assert page.total_pages == 2
     end
 
+    it "can be provided the current page and page size as a atom params map" do
+      posts = create_posts
+
+      page = Post
+      |> Post.published
+      |> Scrivener.Repo.paginate(%{page: 2, page_size: 3})
+
+      assert page.page_size == 3
+      assert page.page_number == 2
+      assert page.entries == Enum.drop(posts, 3)
+      assert page.total_pages == 2
+    end
+
     it "can be provided the current page and page size as options" do
       posts = create_posts
 


### PR DESCRIPTION
It's not obviously that params map should contains strings.  Params with atoms using in [maru](https://github.com/falood/maru).
And now, instead of:
```elixir
Repo.paginate(page: params.page, page_size: params.page_size)
```
in maru route you can just write
```elixir
Repo.paginate(params)
```

P.S. I'm not sure about params fetching order. It seems like it will be faster to fetch value by atom and then try by string but most users uses Phoenix where params keys are strings.