### PR TITLE
Update Ecto dep to version 2.0.0-beta1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Scrivener.Mixfile do
 
   defp deps do
     [
-      {:ecto, "~> 1.0"},
+      {:ecto, "~> 2.0.0-beta"},
       {:dialyze, "~> 0.2.0", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev},
       {:ex_doc, "~> 0.11.0", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "decimal": {:hex, :decimal, "1.1.1"},
   "dialyze": {:hex, :dialyze, "0.2.0"},
   "earmark": {:hex, :earmark, "0.2.1"},
-  "ecto": {:hex, :ecto, "1.1.3"},
+  "ecto": {:hex, :ecto, "2.0.0-beta.1"},
   "ex_doc": {:hex, :ex_doc, "0.11.4"},
   "ex_spec": {:hex, :ex_spec, "1.0.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -9,11 +9,9 @@ defmodule Scrivener.TestCase do
   end
 
   setup do
-    Ecto.Adapters.SQL.begin_test_transaction(Scrivener.Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Scrivener.Repo, :manual)
 
-    ExUnit.Callbacks.on_exit(fn ->
-      Ecto.Adapters.SQL.rollback_test_transaction(Scrivener.Repo)
-    end)
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Scrivener.Repo)
   end
 end
 


### PR DESCRIPTION
This is the first step to update Scrivener to use Ecto 2+ (it is using the beta version). The tests are green and my internal app is running as well. Waiting for the final release.

Ref.: http://blog.plataformatec.com.br/2016/02/ecto-2-0-0-beta-0-is-out