### PR TITLE
Mention Scrivener.Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ First, you'll want to `use` Scrivener in your application's Repo. This will add 
 
 You may also want to call `paginate` with a params map along with your query. If provided with a params map, Scrivener will use the values in the keys `"page"` and `"page_size"` before using any configured defaults.
 
-See [Scrivener.HTML](https://github.com/mgwidmann/scrivener_html) for generating HTML output using Bootstrap or other frameworks.
+See [Scrivener.HTML](https://github.com/mgwidmann/scrivener_html) for generating HTML output using Bootstrap or other frameworks. For API pagination see [Scrivener.Headers](https://github.com/doomspork/scrivener_headers).
 
 ## Example
 


### PR DESCRIPTION
Hi @drewolson, big thank you for Scrivener!  

I needed to use HTTP headers for pagination so I put together [Scrivener.Headers](https://github.com/doomspork/scrivener_headers).  Others might find it useful so I thought it was worth mentioning in the README.  If not, no worries :grinning: 

If you have any thoughts or feedback on `Scrivener.Headers` I'd love to hear them.