### PR TITLE
Implement Enumerable protocol for Scrivener.Page.

### DIFF
--- a/lib/scrivener/page.ex
+++ b/lib/scrivener/page.ex
@@ -14,4 +14,21 @@ defmodule Scrivener.Page do
   defstruct [:entries, :page_number, :page_size, :total_entries, :total_pages]
 
   @type t :: %__MODULE__{}
+
+  defimpl Enumerable, for: __MODULE__ do
+    def reduce(%{entries: entries}, acc, fun) when is_list(entries) do
+      do_reduce(entries, acc, fun)
+    end
+    def reduce(_, acc, fun), do: do_reduce([], acc, fun)
+
+    defp do_reduce(_,       {:halt, acc}, _fun),   do: {:halted, acc}
+    defp do_reduce(entries, {:suspend, acc}, fun), do: {:suspended, acc, &do_reduce(entries, &1, fun)}
+    defp do_reduce([],      {:cont, acc}, _fun),   do: {:done, acc}
+    defp do_reduce([h|t],   {:cont, acc}, fun),    do: do_reduce(t, fun.(h, acc), fun)
+
+    def member?(_page, _value),
+      do: {:error, __MODULE__}
+    def count(_page),
+      do: {:error, __MODULE__}
+  end
 end

--- a/lib/scrivener/page.ex
+++ b/lib/scrivener/page.ex
@@ -16,19 +16,15 @@ defmodule Scrivener.Page do
   @type t :: %__MODULE__{}
 
   defimpl Enumerable, for: __MODULE__ do
-    def reduce(%{entries: entries}, acc, fun) when is_list(entries) do
-      do_reduce(entries, acc, fun)
+    alias Scrivener.Page
+
+    def reduce(%Page{entries: entries}, acc, fun) when is_list(entries) do
+      Enumerable.reduce(entries, acc, fun)
     end
-    def reduce(_, acc, fun), do: do_reduce([], acc, fun)
 
-    defp do_reduce(_,       {:halt, acc}, _fun),   do: {:halted, acc}
-    defp do_reduce(entries, {:suspend, acc}, fun), do: {:suspended, acc, &do_reduce(entries, &1, fun)}
-    defp do_reduce([],      {:cont, acc}, _fun),   do: {:done, acc}
-    defp do_reduce([h|t],   {:cont, acc}, fun),    do: do_reduce(t, fun.(h, acc), fun)
-
-    def member?(_page, _value),
-      do: {:error, __MODULE__}
-    def count(_page),
-      do: {:error, __MODULE__}
+    def member?(%Page{entries: entries}, value),
+      do: {:ok, Enum.member?(entries, value)}
+    def count(%Page{entries: entries}),
+      do: {:ok, Enum.count(entries)}
   end
 end

--- a/test/scrivener/page_test.exs
+++ b/test/scrivener/page_test.exs
@@ -1,0 +1,30 @@
+defmodule Scrivener.Page do
+  use Scrivener.TestCase
+
+  alias Scrivener.Page
+  alias Scrivener.Post
+
+  describe "enumerable protocol implementation" do
+    context "when entries field is missing" do
+      it "considers page to be an empty collection" do
+        page = Map.delete(%Page{}, :entries)
+
+        assert Enum.count(page) == 0
+      end
+    end
+
+    context "when entries field is nil" do
+      it "considers page to be an empty collection" do
+        assert Enum.count(%Page{}) == 0
+      end
+    end
+
+    context "when entries field is a list" do
+      it "considers page to be a collection" do
+        page = %Page{entries: [%Post{}, %Post{}]}
+
+        assert Enum.count(page) == 2
+      end
+    end
+  end
+end

--- a/test/scrivener/page_test.exs
+++ b/test/scrivener/page_test.exs
@@ -1,29 +1,37 @@
-defmodule Scrivener.Page do
+defmodule Scrivener.PageTest do
   use Scrivener.TestCase
 
   alias Scrivener.Page
   alias Scrivener.Post
 
   describe "enumerable protocol implementation" do
-    context "when entries field is missing" do
-      it "considers page to be an empty collection" do
-        page = Map.delete(%Page{}, :entries)
+    describe "reduce" do
+      it "reduces entries collection" do
+        page = %Page{entries: [%Post{published: false}, %Post{published: true}]}
 
-        assert Enum.count(page) == 0
+        posts = Enum.reduce(page, [], fn
+          (%{published: true} = post, acc) -> [post|acc]
+          (%{published: false}, acc) -> acc
+        end)
+
+        assert Enum.all?(posts, fn(post) -> post.published end)
       end
     end
 
-    context "when entries field is nil" do
-      it "considers page to be an empty collection" do
-        assert Enum.count(%Page{}) == 0
+    describe "count" do
+      it "returns size of entries" do
+        assert Enum.count(%Page{entries: [%Post{}]}) == 1
+        assert Enum.count(%Page{entries: []}) == 0
       end
     end
 
-    context "when entries field is a list" do
-      it "considers page to be a collection" do
-        page = %Page{entries: [%Post{}, %Post{}]}
+    describe "member?" do
+      it "checks if value exists within entries" do
+        post = %Post{title: "Hola"}
+        page = %Page{entries: [post]}
 
-        assert Enum.count(page) == 2
+        assert Enum.member?(page, post)
+        refute Enum.member?(page, %Post{title: "Hello"})
       end
     end
   end

--- a/test/scrivener_test.exs
+++ b/test/scrivener_test.exs
@@ -206,10 +206,8 @@ defmodule ScrivenerTest do
       |> Scrivener.Repo.paginate
 
       assert Enum.count(page) == 5
-
-      Enum.each(page, fn(post) ->
-        assert post.published == true
-      end)
+      refute Enum.member?(page, %Post{title: "Nonexistent"})
+      assert Enum.all?(page, fn(post) -> post.published end)
     end
   end
 end

--- a/test/scrivener_test.exs
+++ b/test/scrivener_test.exs
@@ -197,5 +197,19 @@ defmodule ScrivenerTest do
       assert first.body == "Body 3"
       assert second.body == "Body 2"
     end
+
+    it "returns enumerable page" do
+      create_posts
+
+      page = Post
+      |> Post.published
+      |> Scrivener.Repo.paginate
+
+      assert Enum.count(page) == 5
+
+      Enum.each(page, fn(post) ->
+        assert post.published == true
+      end)
+    end
   end
 end


### PR DESCRIPTION
It should be easy to enumerate over page without explicitly accessing entries field.

```elixir
# controller
people = MyApp.Person
|> MyApp.Repo.paginate()

render conn, :index, people: people

# in view, enumerate over people without accessing entries
<%= for person <- @people do %>
  <%= person.name %>
<% end %>
```