### PR TITLE
Add ability to pass nil to Config and get defaults

### DIFF
--- a/lib/scrivener/config.ex
+++ b/lib/scrivener/config.ex
@@ -14,9 +14,14 @@ defmodule Scrivener.Config do
   @type t :: %__MODULE__{}
 
   @doc false
+  def new(module, defaults, nil) do
+    new(module, defaults, %{})
+  end
+
+  @doc false
   def new(module, defaults, options) do
     options = normalize_options(options)
-    page_number = options["page"] |> to_int(1)
+    page_number = options["page_number"] |> to_int(1)
 
     %Scrivener.Config{
       module: module,

--- a/lib/scrivener/config.ex
+++ b/lib/scrivener/config.ex
@@ -21,7 +21,7 @@ defmodule Scrivener.Config do
   @doc false
   def new(module, defaults, options) do
     options = normalize_options(options)
-    page_number = options["page_number"] |> to_int(1)
+    page_number = options["page"] |> to_int(1)
 
     %Scrivener.Config{
       module: module,

--- a/test/scrivener/config_test.exs
+++ b/test/scrivener/config_test.exs
@@ -4,6 +4,14 @@ defmodule Scrivener.ConfigTest do
   alias Scrivener.Config
 
   describe "new" do
+    test "can be provided options as nil" do
+      config = Config.new(:module, [], nil)
+
+      assert config.module == :module
+      assert config.page == 1
+      assert config.page_size == 10
+    end
+
     test "can be provided options as a keyword" do
       config = Config.new(:module, [], page: 2, page_size: 15)
 

--- a/test/scrivener/config_test.exs
+++ b/test/scrivener/config_test.exs
@@ -8,7 +8,7 @@ defmodule Scrivener.ConfigTest do
       config = Config.new(:module, [], nil)
 
       assert config.module == :module
-      assert config.page == 1
+      assert config.page_number == 1
       assert config.page_size == 10
     end
 


### PR DESCRIPTION
This is useful when passing in arguments from plug, and nesting the
scrivener params in something like "page" and the params happen to not be passed

Example:
```elixir
def index(conn, _params) do
  page =
    User
    |> where([p], p.age > 30)
    |> Repo.paginate(conn.query_params["page"] || %{})
  #...
end
```
vs.

```elixir
def index(conn, _params) do
  page =
    User
    |> where([p], p.age > 30)
    |> Repo.paginate(conn.query_params["page"])
  #...
end
```

I also noticed that the test expectations were the default scrivener provides, upon changing
them I noticed that the tests were failing. Tests were specifying "page_number" and the code as looking for "page", so I changed the code to look for page_number and the tests to use non-default values so you can actually see that they are being set