### PR TITLE
Removed "config/" folder, since it was unused

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,0 @@
-use Mix.Config
-
-import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,0 @@
-use Mix.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,1 +1,0 @@
-use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,1 +1,0 @@
-use Mix.Config


### PR DESCRIPTION
Is there any specific reason why it should be presented, which I am missing?

Moreover, I have tested `scrivener_ecto` to be working with my version:

`mix.exs`:

```elixir
  defp deps do
    [
      {:scrivener, github: "sobolevn/scrivener"},
      ...
    ]
```

Running tests:

> [9:04:16] sobolev :: MacBook-Pro-Nikita  ➜  Documents/github/scrivener_ecto ‹master*› » mix test                                
> ...........
> 
> Finished in 0.3 seconds
> 11 tests, 0 failures
> 
> Randomized with seed 941947