### PR TITLE
Add option to set min_page_number

### DIFF
--- a/lib/scrivener/config.ex
+++ b/lib/scrivener/config.ex
@@ -4,6 +4,7 @@ defmodule Scrivener.Config do
 
       %Scrivener.Config{
         page_number: 2,
+        min_page_number: 1, # optional
         page_size: 5,
         max_page_size: 50, # optional
         module: MyApp.Repo
@@ -22,11 +23,10 @@ defmodule Scrivener.Config do
   @doc false
   def new(module, defaults, options) do
     options = normalize_options(options)
-    page_number = options["page"] |> to_int(1)
 
     %Scrivener.Config{
       module: module,
-      page_number: page_number,
+      page_number: page_number(defaults, options),
       page_size: page_size(defaults, options)
     }
   end
@@ -46,6 +46,15 @@ defmodule Scrivener.Config do
     Enum.reduce(options, %{}, fn {k, v}, map ->
       Map.put(map, to_string(k), v)
     end)
+  end
+
+  def page_number(defaults, opts) do
+    page = opts["page"] |> to_int(1)
+
+    case defaults[:min_page_number] do
+      nil -> page
+      n   -> Enum.max([page, n])
+    end
   end
 
   def page_size(defaults, opts) do

--- a/test/scrivener/config_test.exs
+++ b/test/scrivener/config_test.exs
@@ -59,5 +59,12 @@ defmodule Scrivener.ConfigTest do
       assert config.page_number == 1
       assert config.page_size == 10
     end
+
+    test "can provide min_page_number option as a keyword" do
+      config = Config.new(:module, [min_page_number: 1], %{"page" => "-1"})
+
+      assert config.module == :module
+      assert config.page_number == 1
+    end
   end
 end


### PR DESCRIPTION
If you're using scrivener_ecto and you edit the url to a page less than 1 then you will get the following error.

```
(Postgrex.Error) ERROR (invalid_row_count_in_result_offset_clause): OFFSET must not be negative
```

The min_page_number option is to prevent this.