### PR TITLE
show totals config option

### DIFF
--- a/lib/scrivener/config.ex
+++ b/lib/scrivener/config.ex
@@ -1,15 +1,17 @@
 defmodule Scrivener.Config do
   @moduledoc """
-  A `Scrivener.Config` can be created with a `page_number`, a `page_size` and a `module`.
+  A `Scrivener.Config` can be created with a `page_number`, a `page_size`, a `module`
+  and  a `show_totals` option.
 
       %Scrivener.Config{
         page_number: 2,
         page_size: 5,
         module: MyApp.Repo
+        show_totals: false,
       }
   """
 
-  defstruct [:module, :page_number, :page_size]
+  defstruct [:module, :page_number, :page_size, :show_totals]
 
   @type t :: %__MODULE__{}
 
@@ -22,11 +24,13 @@ defmodule Scrivener.Config do
   def new(module, defaults, options) do
     options = normalize_options(options)
     page_number = options["page"] |> to_int(1)
+    show_totals = options["show_totals"] |> default_show_totals
 
     %Scrivener.Config{
       module: module,
       page_number: page_number,
-      page_size: page_size(defaults, options)
+      page_size: page_size(defaults, options),
+      show_totals: show_totals
     }
   end
 
@@ -53,6 +57,9 @@ defmodule Scrivener.Config do
 
     min(requested_page_size, defaults[:max_page_size])
   end
+
+  defp default_show_totals(bool) when is_boolean(bool), do: bool
+  defp default_show_totals(_), do: true
 
   defp to_int(:error, default), do: default
   defp to_int(nil, default), do: default

--- a/test/scrivener/config_test.exs
+++ b/test/scrivener/config_test.exs
@@ -67,5 +67,28 @@ defmodule Scrivener.ConfigTest do
       assert config.page_number == 1
       assert config.page_size == 10
     end
+
+    test "can provide show_totals option as a keyword" do
+      config = Config.new(:module, [show_totals: true], %{"show_totals" => false})
+
+      assert config.module == :module
+      assert config.page_number == 1
+      assert config.page_size == 10
+      assert config.show_totals == false
+    end
+
+      test "defaults show_totals to true" do
+      config = Config.new(%{"module" => :module})
+
+      assert config.module == :module
+      assert config.show_totals == true
+    end
+
+    test "defaults non-boolean show_totals option appropriately" do
+      config = Config.new(%{"module" => :module, "show_totals" => "-15"})
+
+      assert config.module == :module
+      assert config.show_totals == true
+    end
   end
 end


### PR DESCRIPTION
@drewolson here's the PR for the show_totals option (#45)

Should be backwards compatible since the struct can't be initialized w/out a boolean value for the show_totals field. All existing tests pass / added a couple new ones.

I'm happy to PR some added tests / updated scrivener dep / readme to scrivener_ecto if we get this merged too!

Let me know if you have any feedback, cheers.