### PR TITLE
Prepare support for specifying “last” as page number

### DIFF
--- a/lib/scrivener/config.ex
+++ b/lib/scrivener/config.ex
@@ -25,7 +25,10 @@ defmodule Scrivener.Config do
   @doc false
   def new(module, defaults, options) do
     options = normalize_options(options)
-    page_number = options["page"] |> to_int(1)
+    page_number = case options["page"] do
+      "last" -> "last"
+      _ -> options["page"] |> to_int(1)
+    end
 
     %Scrivener.Config{
       caller: Map.get(options, "caller", self()),

--- a/test/scrivener/config_test.exs
+++ b/test/scrivener/config_test.exs
@@ -36,6 +36,12 @@ defmodule Scrivener.ConfigTest do
       assert config.page_size == 15
     end
 
+    test "does not convert the special page number value of 'last' to an integer" do
+      config = Config.new(:module, [], %{"page" => "last"})
+
+      assert config.page_number == "last"
+    end
+
     test "can be provided page size via defaults" do
       config = Config.new(:module, [page_size: 15], %{"page" => "2"})
 


### PR DESCRIPTION
Add support for specifying the special page number “last”.
These changes only allow specifying this special page number without it being converted to an integer. The actual handling of loading the last page will be implemented in Scrivener.Ecto