### PR TITLE
Implement collectable

### DIFF
--- a/lib/scrivener/page.ex
+++ b/lib/scrivener/page.ex
@@ -15,15 +15,20 @@ defmodule Scrivener.Page do
 
   @type t :: %__MODULE__{}
 
-  defimpl Enumerable, for: Scrivener.Page do
+  defimpl Enumerable do
+    @spec count(Scrivener.Page.t()) :: {:error, Enumerable.Scrivener.Page}
     def count(_page), do: {:error, __MODULE__}
 
+    @spec member?(Scrivener.Page.t(), term) :: {:error, Enumerable.Scrivener.Page}
     def member?(_page, _value), do: {:error, __MODULE__}
 
+    @spec reduce(Scrivener.Page.t(), Enumerable.acc(), Enumerable.reducer()) ::
+            Enumerable.result()
     def reduce(%Scrivener.Page{entries: entries}, acc, fun) do
       Enumerable.reduce(entries, acc, fun)
     end
 
+    @spec slice(Scrivener.Page.t()) :: {:error, Enumerable.Scrivener.Page}
     def slice(_page), do: {:error, __MODULE__}
   end
 end

--- a/lib/scrivener/page.ex
+++ b/lib/scrivener/page.ex
@@ -31,4 +31,20 @@ defmodule Scrivener.Page do
     @spec slice(Scrivener.Page.t()) :: {:error, Enumerable.Scrivener.Page}
     def slice(_page), do: {:error, __MODULE__}
   end
+
+  defimpl Collectable do
+    @spec into(Scrivener.Page.t()) ::
+            {term, (term, Collectable.command() -> Scrivener.Page.t() | term)}
+    def into(original) do
+      original_entries = original.entries
+      impl = Collectable.impl_for(original_entries)
+      {_, entries_fun} = impl.into(original_entries)
+
+      fun = fn page, command ->
+        %{page | entries: entries_fun.(page.entries, command)}
+      end
+
+      {original, fun}
+    end
+  end
 end

--- a/lib/scrivener/page.ex
+++ b/lib/scrivener/page.ex
@@ -11,7 +11,7 @@ defmodule Scrivener.Page do
       page.total_pages
   """
 
-  defstruct [:entries, :page_number, :page_size, :total_entries, :total_pages]
+  defstruct [:page_number, :page_size, :total_entries, :total_pages, entries: []]
 
   @type t :: %__MODULE__{}
 

--- a/test/scrivener/page_test.exs
+++ b/test/scrivener/page_test.exs
@@ -13,5 +13,9 @@ defmodule Scrivener.PageTest do
 
       assert titles == ["post 1", "post 2"]
     end
+
+    test "behaviour when empty" do
+      assert [] = Enum.map(%Page{}, &Map.get(&1, :title))
+    end
   end
 end

--- a/test/scrivener/page_test.exs
+++ b/test/scrivener/page_test.exs
@@ -18,4 +18,11 @@ defmodule Scrivener.PageTest do
       assert [] = Enum.map(%Page{}, &Map.get(&1, :title))
     end
   end
+
+  describe "collectable" do
+    post1 = %{title: "post 1"}
+    post2 = %{title: "post 2"}
+
+    assert %Page{entries: [^post1, ^post2]} = Enum.into([post1, post2], %Page{})
+  end
 end


### PR DESCRIPTION
This would allow people to do things like:
```
for entry <- page, into: %{page | entries: []}, do: computed_values(entry)
```

On the way I noticed that currently the enumerable implementation fails for pages created manually without entries, so I made it default to `[]`. Tech. I think this is a breaking change, but I'm not sure how many people actually depend on it as you most often will use it coming out of ecto, where the entries key will be set to `[]` for empty results.