### PR TITLE
Stricter types

### DIFF
--- a/lib/scrivener.ex
+++ b/lib/scrivener.ex
@@ -38,7 +38,7 @@ defmodule Scrivener do
   end
 
   @doc false
-  @spec paginate(any, map | Keyword.t()) :: Scrivener.Page.t()
+  @spec paginate(any, Scrivener.Config.t() | map | Keyword.t()) :: Scrivener.Page.t()
   def paginate(pageable, %Scrivener.Config{} = config) do
     Scrivener.Paginater.paginate(pageable, config)
   end

--- a/lib/scrivener.ex
+++ b/lib/scrivener.ex
@@ -37,8 +37,10 @@ defmodule Scrivener do
     end
   end
 
+  @typep convertable_to_config :: map | Keyword.t()
+
   @doc false
-  @spec paginate(any, Scrivener.Config.t() | map | Keyword.t()) :: Scrivener.Page.t()
+  @spec paginate(any, Scrivener.Config.t() | convertable_to_config()) :: Scrivener.Page.t()
   def paginate(pageable, %Scrivener.Config{} = config) do
     Scrivener.Paginater.paginate(pageable, config)
   end

--- a/lib/scrivener.ex
+++ b/lib/scrivener.ex
@@ -38,13 +38,12 @@ defmodule Scrivener do
   end
 
   @doc false
-  @spec paginate(any, Scrivener.Config.t()) :: Scrivener.Page.t()
+  @spec paginate(any, map | Keyword.t()) :: Scrivener.Page.t()
   def paginate(pageable, %Scrivener.Config{} = config) do
     Scrivener.Paginater.paginate(pageable, config)
   end
 
   @doc false
-  @spec paginate(any, map | Keyword.t()) :: Scrivener.Page.t()
   def paginate(pageable, options) do
     Scrivener.paginate(pageable, Scrivener.Config.new(options))
   end

--- a/lib/scrivener/page.ex
+++ b/lib/scrivener/page.ex
@@ -13,7 +13,13 @@ defmodule Scrivener.Page do
 
   defstruct [:page_number, :page_size, :total_entries, :total_pages, entries: []]
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+          entries: list(),
+          page_number: pos_integer(),
+          page_size: integer(),
+          total_entries: integer(),
+          total_pages: pos_integer()
+        }
 
   defimpl Enumerable do
     @spec count(Scrivener.Page.t()) :: {:error, Enumerable.Scrivener.Page}


### PR DESCRIPTION
This makes the `@type t` for `Page` a little stricter. I also ran `mix dialyzer`, and fixed an overloaded contract.

I still get these error:
```
$ mix dialyzer
Finding suitable PLTs
Checking PLT...
[:compiler, :elixir, :kernel, :logger, :stdlib]
PLT is up to date!
Starting Dialyzer
[
  check_plt: false,
  init_plt: '/home/kbaird/repos/scrivener/_build/dev/dialyxir_erlang-21.3.3_elixir-1.8.1_deps-dev.plt',
  files_rec: ['/home/kbaird/repos/scrivener/_build/dev/lib/scrivener/ebin'],
  warnings: [:unknown]
]
Total errors: 11, Skipped: 0
done in 0m1.17s
:0:unknown_function
Function Scrivener.Paginater.Atom.__impl__/1 does not exist.
________________________________________________________________________________
:0:unknown_function
Function Scrivener.Paginater.BitString.__impl__/1 does not exist.
________________________________________________________________________________
:0:unknown_function
Function Scrivener.Paginater.Float.__impl__/1 does not exist.
________________________________________________________________________________
:0:unknown_function
Function Scrivener.Paginater.Function.__impl__/1 does not exist.
________________________________________________________________________________
:0:unknown_function
Function Scrivener.Paginater.Integer.__impl__/1 does not exist.
________________________________________________________________________________
:0:unknown_function
Function Scrivener.Paginater.List.__impl__/1 does not exist.
________________________________________________________________________________
:0:unknown_function
Function Scrivener.Paginater.Map.__impl__/1 does not exist.
________________________________________________________________________________
:0:unknown_function
Function Scrivener.Paginater.PID.__impl__/1 does not exist.
________________________________________________________________________________
:0:unknown_function
Function Scrivener.Paginater.Port.__impl__/1 does not exist.
________________________________________________________________________________
:0:unknown_function
Function Scrivener.Paginater.Reference.__impl__/1 does not exist.
________________________________________________________________________________
:0:unknown_function
Function Scrivener.Paginater.Tuple.__impl__/1 does not exist.
________________________________________________________________________________
done (warnings were emitted)
```

I figure that's outside the scope of what I'm trying to do, but thought it worth mentioning.