### PR TITLE
Typing with arguments

### DIFF
--- a/lib/scrivener/page.ex
+++ b/lib/scrivener/page.ex
@@ -20,6 +20,13 @@ defmodule Scrivener.Page do
           total_entries: integer(),
           total_pages: pos_integer()
         }
+  @type t(entry) :: %__MODULE__{
+          entries: list(entry),
+          page_number: pos_integer(),
+          page_size: integer(),
+          total_entries: integer(),
+          total_pages: pos_integer()
+        }
 
   defimpl Enumerable do
     @spec count(Scrivener.Page.t()) :: {:error, Enumerable.Scrivener.Page}

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Scrivener.Mixfile do
       app: :scrivener,
       version: "2.7.0",
       elixir: "~> 1.2",
+      elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       description: "Pagination for the Elixir ecosystem",
       deps: deps(),
@@ -24,6 +25,9 @@ defmodule Scrivener.Mixfile do
       extra_applications: [:logger]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp deps do
     [

--- a/test/scrivener/page_test.exs
+++ b/test/scrivener/page_test.exs
@@ -2,11 +2,12 @@ defmodule Scrivener.PageTest do
   use Scrivener.TestCase
 
   alias Scrivener.Page
+  alias Scrivener.Post
 
   describe "enumerable" do
     test "implements enumerable" do
-      post1 = %{title: "post 1"}
-      post2 = %{title: "post 2"}
+      post1 = %Post{title: "post 1"}
+      post2 = %Post{title: "post 2"}
       page = %Page{entries: [post1, post2]}
 
       titles = Enum.map(page, &Map.get(&1, :title))
@@ -20,9 +21,14 @@ defmodule Scrivener.PageTest do
   end
 
   describe "collectable" do
-    post1 = %{title: "post 1"}
-    post2 = %{title: "post 2"}
+    @spec build_post_page(list(Post.t())) :: Page.t(Post.t())
+    def build_post_page(list), do: Enum.into(list, %Page{})
 
-    assert %Page{entries: [^post1, ^post2]} = Enum.into([post1, post2], %Page{})
+    test "implements collectable" do
+      post1 = %Post{title: "post 1"}
+      post2 = %Post{title: "post 2"}
+
+      assert %Page{entries: [^post1, ^post2]} = build_post_page([post1, post2])
+    end
   end
 end

--- a/test/support/page.ex
+++ b/test/support/page.ex
@@ -1,0 +1,4 @@
+defmodule Scrivener.Post do
+  defstruct title: ""
+  @type t :: %__MODULE__{title: String.t()}
+end


### PR DESCRIPTION
Motivation is to make the wrapper function more stricter by passing `Post.t` to `Page.t` like `list(Post.t())`.