### PR TITLE
Update Link to Scrivener Headers Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ only responding to pull requests and breaking issues.
 
 * [Scrivener.Ecto](https://github.com/drewolson/scrivener_ecto) paginate your Ecto queries with Scrivener
 * [Scrivener.HTML](https://github.com/mgwidmann/scrivener_html) generates HTML output using Bootstrap or other frameworks
-* [Scrivener.Headers](https://github.com/doomspork/scrivener_headers) adds response headers for API pagination
+* [Scrivener.Headers](https://github.com/beam-community/scrivener_headers) adds response headers for API pagination
 * [Scrivener.List](https://github.com/stephenmoloney/scrivener_list) allows pagination of a list
 
 ## Installation


### PR DESCRIPTION
# Overview

Updated the link for the scrivener headers repo to the new location (in beam-community org).

Related to https://github.com/beam-community/scrivener_headers/issues/11 . 